### PR TITLE
fix: backport security fixes for multiple CVEs in webkit2gtk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+webkit2gtk (2.50.4-1~deb12u1deepin2) unstable; urgency=medium
+
+  * Security update (CVE-2026-20652):
+    - Fix integer underflow in AudioResamplerKernel::getSourceSpan().
+      + Add debian/patches/CVE-2026-20652.patch.
+  * Security fixes already present in upstream 2.50.4:
+    - CVE-2023-43010: Use-after-free in RenderTree.
+    - CVE-2025-31223: Memory corruption via improved checks.
+    - CVE-2025-31277: Memory corruption in JSC RegExp match results.
+    - CVE-2025-43433: Memory corruption via improved memory handling.
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 07 Apr 2026 16:45:00 +0800
+
 webkit2gtk (2.50.4-1~deb12u1deepin1) unstable; urgency=medium
 
   * [ hudeng ]

--- a/debian/patches/CVE-2026-20652.patch
+++ b/debian/patches/CVE-2026-20652.patch
@@ -1,0 +1,46 @@
+commit 651ac71c62e521569634ef365572775997437cdb
+Author: Jer Noble <jer.noble@apple.com>
+Date:   Thu Dec 11 00:55:20 2025 -0800
+
+    Cherry-pick 301765.369@safari-7623-branch (ee36b92f6f9f). https://bugs.webkit.org/show_bug.cgi?id=303959
+    
+        Integer underflow in AudioResamplerKernel::getSourceSpan()
+        rdar://162552376
+        https://bugs.webkit.org/show_bug.cgi?id=303959
+    
+        Reviewed by Eric Carlson.
+    
+        Protect against underflows when calculating the number of
+        source frames needed using WTF::safeSub().
+    
+        * Source/WebCore/platform/audio/AudioResamplerKernel.cpp:
+        (WebCore::AudioResamplerKernel::getSourceSpan):
+    
+        Identifier: 301765.369@safari-7623-branch
+    
+    Canonical link: https://commits.webkit.org/298234.449@webkitglib/2.50
+
+diff --git a/Source/WebCore/platform/audio/AudioResamplerKernel.cpp b/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
+index 4d64f8ff81c..e5bcb5e1f61 100644
+--- a/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
++++ b/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
+@@ -31,6 +31,7 @@
+ #include "AudioResampler.h"
+ #include "AudioUtilities.h"
+ #include <algorithm>
++#include <wtf/CheckedArithmetic.h>
+ #include <wtf/TZoneMallocInlines.h>
+ 
+ namespace WebCore {
+@@ -58,7 +59,10 @@ std::span<float> AudioResamplerKernel::getSourceSpan(size_t framesToProcess, siz
+ 
+     // Determine how many input frames we'll need.
+     // We need to fill the buffer up to and including endIndex (so add 1) but we've already buffered m_fillIndex frames from last time.
+-    size_t framesNeeded = 1 + endIndex - m_fillIndex;
++    size_t framesNeeded;
++    if (!WTF::safeSub(1 + endIndex, m_fillIndex, framesNeeded))
++        return { };
++
+     if (numberOfSourceFramesNeededP)
+         *numberOfSourceFramesNeededP = framesNeeded;
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@ fix-ftbfs-x32.patch
 disable-nvidia-dmabuf.patch
 fix-minibrowser.patch
 0001-deepin-sw_64-support.diff
+CVE-2026-20652.patch


### PR DESCRIPTION
## Summary

Backport upstream security fixes to address the following CVEs:

- **CVE-2026-20652**: Patched via new Debian quilt patch (`CVE-2026-20652.patch`). Fixes an integer underflow in `AudioResamplerKernel::getSourceSpan()`.
- **CVE-2023-43010**: Already fixed in upstream 2.44.0 (current source 2.50.4 includes the fix). Explicitly declared in changelog.
- **CVE-2025-31223**: Already fixed in upstream 2.50.0. Explicitly declared in changelog.
- **CVE-2025-31277**: Already fixed in upstream 2.50.0 (verified in `JSGlobalObjectInlines.h`). Explicitly declared in changelog.
- **CVE-2025-43433**: Already fixed in upstream 2.50.2. Explicitly declared in changelog.

## Changes

- `debian/patches/CVE-2026-20652.patch`: New patch backported from WebKitGTK 2.50.6 (upstream commit `651ac71c62`).
- `debian/patches/series`: Added `CVE-2026-20652.patch`.
- `debian/changelog`: Bumped version to `2.50.4-1~deb12u1deepin2` and documented all CVE fixes.

## Test Plan

- [ ] Build webkit2gtk with the new patch applied.
- [ ] Verify no regression in WebAudio resampler code path.
- [ ] Validate Debian quilt patch applies cleanly during package build.